### PR TITLE
デグレード発生で、CountdownTimerAPIを踏まえて、一度Handlerの実装に戻す。

### DIFF
--- a/app/src/main/java/com/github/dev001hajipro/notorekraepelin/ui/game/GameViewModel.kt
+++ b/app/src/main/java/com/github/dev001hajipro/notorekraepelin/ui/game/GameViewModel.kt
@@ -2,10 +2,12 @@ package com.github.dev001hajipro.notorekraepelin.ui.game
 
 import android.app.Application
 import android.os.CountDownTimer
+import android.os.Handler
 import android.util.Log
 import androidx.lifecycle.AndroidViewModel
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.Transformations
 import com.github.dev001hajipro.notorekraepelin.Event
 import com.github.dev001hajipro.notorekraepelin.Kraepelin
 
@@ -13,10 +15,27 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
 
     private val tag: String = GameViewModel::class.java.simpleName
 
+    private val countDownInterval = 1000L
+    private val handler = Handler()
+
+    // 制限時間
+    private val _millisecondsUntilFinished = MutableLiveData(0L)
+    val millisecondsUntilFinished: LiveData<Long> = _millisecondsUntilFinished
+
+    // 経過時間
+    private val _elapsedMilliSeconds = MutableLiveData(0L)
+    val elapsedMilliSeconds: LiveData<Long> = _elapsedMilliSeconds
+
+    // 残り時間 = 制限時間 - 経過時間
+    val remainingMilliseconds = Transformations.map(elapsedMilliSeconds) { n ->
+        millisecondsUntilFinished.value?.minus(n)
+    }
+
     // タイマーℤ
-    private lateinit var timer: CountDownTimer
-    private val _millisUntilFinishedForResume = MutableLiveData<Long>(0L)
-    var millisUntilFinishedForResume = _millisUntilFinishedForResume
+    //private lateinit var timer: CountDownTimer
+    // レジューム対応残り時間
+    //private val _millisUntilFinishedForResume = MutableLiveData<Long>(0L)
+    //var millisUntilFinishedForResume = _millisUntilFinishedForResume
 
     var q1 = MutableLiveData(0)
     var q2 = MutableLiveData(0)
@@ -27,6 +46,9 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
     var cursorIndex = 0
     // UI側から変更なし
     private var lines = MutableList(15) { Kraepelin.generateTest() }
+
+    private var lineCount = 0
+
     // UI側から変更なし
     // 一行ごとの正解数
     private var scores = MutableList(15) { 0 }
@@ -40,15 +62,15 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
 
     // 評価=正解数/秒
     fun grade(): Float {
-        return (scores.sum().toFloat() / ((millisUntilFinishedForResume.value
+        //return (scores.sum().toFloat() / ((millisUntilFinishedForResume.value ?: 60000) / 1000L).toFloat())
+        return (scores.sum().toFloat() / ((_millisecondsUntilFinished.value
             ?: 60000) / 1000L).toFloat())
     }
-
-    private var lineCount = 0
 
     private val _navigateToGameResultEvent = MutableLiveData<Event<String>>()
     val navigateToGameResultEvent: LiveData<Event<String>> = _navigateToGameResultEvent
 
+    /*
     private fun timer(millisInFuture: Long, countDownInterval: Long = 100L): CountDownTimer {
         return object : CountDownTimer(millisInFuture, countDownInterval) {
             override fun onFinish() {
@@ -57,9 +79,39 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
 
             override fun onTick(millisUntilFinished: Long) {
                 millisUntilFinishedForResume.value = millisUntilFinished
-                if ((((millisInFuture - millisUntilFinished) / 1000L) % 60) == 0L) { // イベント
+                Log.d(
+                    tag,
+                    "onTick: millisUntilFinishedForResume.value=${millisUntilFinishedForResume.value}, millisInFuture=$millisInFuture, (millisInFuture - millisUntilFinished)=${(millisInFuture - millisUntilFinished)}"
+                )
+                // 1分単位(60000ミリ秒)で行が変わる。
+                // つまり、1分単位で条件が変わるとよい
+                // 経過時間(ミリ秒) > 1分単位(60000ミリ秒) * n ならn++
+                if (((millisUntilFinished) % (60000L * (lineCount + 1))) == 0L) { // イベント
                     cursorIndex = 0
                     lineCount++
+                    Log.d(tag, "onTick: cursorIndex=$cursorIndex, lineCount=$lineCount")
+                }
+            }
+        }
+    }
+     */
+
+    private val runnable = object : Runnable {
+        override fun run() {
+            _elapsedMilliSeconds.value = (_elapsedMilliSeconds.value ?: 0) + 1000L
+            val v = _elapsedMilliSeconds.value ?: 0
+
+            if (v % 60000L == 0L) { // イベント
+                cursorIndex = 0
+                lineCount++
+            }
+
+            _millisecondsUntilFinished.value?.let {
+                if ((_elapsedMilliSeconds.value ?: 0) < it) {
+                    Log.d(tag, "before postDelayed delayMillis=1000, ${_elapsedMilliSeconds.value}")
+                    handler.postDelayed(this, countDownInterval)
+                } else {
+                    _navigateToGameResultEvent.value = Event("")
                 }
             }
         }
@@ -67,7 +119,9 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
 
     fun init(milliseconds: Long = 60000) {
         Log.d(tag, "init")
-        millisUntilFinishedForResume.value = milliseconds
+        _elapsedMilliSeconds.value = 0
+        _millisecondsUntilFinished.value = milliseconds
+        //millisUntilFinishedForResume.value = milliseconds
 
         lineCount = 0
         cursorIndex = 0
@@ -77,12 +131,14 @@ class GameViewModel(application: Application) : AndroidViewModel(application) {
     }
 
     fun onResume() {
-        timer = timer(millisUntilFinishedForResume.value ?: 0)
-        timer.start()
+        //timer = timer(millisUntilFinishedForResume.value ?: 0)
+        //timer.start()
+        handler.postDelayed(runnable, countDownInterval)
     }
 
     fun onPause() {
-        timer.cancel()
+        //timer.cancel()
+        handler.removeCallbacks(runnable)
     }
 
     // TODO クリアボタンで、１つ前の問題に戻る対応。

--- a/app/src/main/res/layout/fragment_game.xml
+++ b/app/src/main/res/layout/fragment_game.xml
@@ -240,7 +240,7 @@
             android:layout_marginStart="16dp"
             android:layout_marginTop="16dp"
             android:layout_marginEnd="16dp"
-            android:text="@{Converter.millisToString(viewModel.millisUntilFinishedForResume)}"
+            android:text="@{Converter.millisToString(viewModel.remainingMilliseconds)}"
             android:textAlignment="center"
             android:textSize="36sp"
             app:layout_constraintEnd_toEndOf="parent"

--- a/app/src/test/java/com/github/dev001hajipro/notorekraepelin/ui/game/GameViewModelTest.kt
+++ b/app/src/test/java/com/github/dev001hajipro/notorekraepelin/ui/game/GameViewModelTest.kt
@@ -29,15 +29,19 @@ class GameViewModelTest {
         // When
         viewModel.init()
         // Then
-        assertThat(viewModel.millisUntilFinishedForResume.getOrAwaitValue(), `is`(60000L))
+        assertThat(viewModel.millisecondsUntilFinished.value, `is`(60_000L))
+        assertThat(viewModel.elapsedMilliSeconds.value, `is`(0L))
+        assertThat(viewModel.remainingMilliseconds.getOrAwaitValue(), `is`(60_000L))
     }
 
     @Test
     fun setInit180_shouldGetSameValue() {
         // When
-        viewModel.init(milliseconds = 180000L)
+        viewModel.init(milliseconds = 180_000L)
         // Then
-        assertThat(viewModel.millisUntilFinishedForResume.getOrAwaitValue(), `is`(180000L))
+        assertThat(viewModel.millisecondsUntilFinished.value, `is`(180_000L))
+        assertThat(viewModel.elapsedMilliSeconds.value, `is`(0L))
+        assertThat(viewModel.remainingMilliseconds.getOrAwaitValue(), `is`(180_000L))
     }
 
     @Test

--- a/app/src/test/java/com/github/dev001hajipro/notorekraepelin/utils/ConverterTest.kt
+++ b/app/src/test/java/com/github/dev001hajipro/notorekraepelin/utils/ConverterTest.kt
@@ -1,0 +1,16 @@
+package com.github.dev001hajipro.notorekraepelin.utils
+
+import org.hamcrest.Matchers.`is`
+import org.junit.Test
+
+import org.junit.Assert.*
+
+class ConverterTest {
+
+    @Test
+    fun millisToString() {
+        val milliSeconds = 60000L
+        val actual = Converter.millisToString(milliSeconds)
+        assertThat(actual, `is`("01:00.0"))
+    }
+}


### PR DESCRIPTION
Close #45 
CountdownTimerはイベントハンドラーで残りミリ秒は保持するが、
開始時間など他の情報がないため、必要ならViewModelで定義。
またはCountDownTimerを継承して実装する。

ViewModelで開始時間の保持などをする場合は、HandlerAPIで実装する方法が分かりやすい。
コードも10行ぐらいの差なのでCountDownTimerで1行で済むなどの大幅な変更はない。

これらを踏まえてHandlerで実装するようにする